### PR TITLE
added geolocation

### DIFF
--- a/React/weather-dashboard/src/App.jsx
+++ b/React/weather-dashboard/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import SearchBar from "./components/SearchBar";
 import WeatherCard from "./components/WeatherCard";
 import Forecast from "./components/Forecast";
@@ -12,6 +12,7 @@ import {
   Box,
   Grid,
 } from "@mui/material";
+import axios from "axios";
 
 const App = () => {
   const [selectedCity, setSelectedCity] = useState('');
@@ -20,6 +21,35 @@ const App = () => {
     setSelectedCity(city);
     console.log(selectedCity);
   };
+
+  // Attempt to auto-detect user location on first load
+  useEffect(() => {
+    if (!("geolocation" in navigator)) return;
+
+    const fetchByCoords = async (lat, lon) => {
+      try {
+        const response = await axios.get(
+          `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${import.meta.env.VITE_OPEN_WEATHER_APP_KEY}&units=metric`
+        );
+        setSelectedCity(response.data);
+      } catch (err) {
+        // Silently ignore; user can search manually
+        // eslint-disable-next-line no-console
+        console.warn("Geolocation weather fetch failed:", err);
+      }
+    };
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        fetchByCoords(latitude, longitude);
+      },
+      () => {
+        // Permission denied or unavailable; do nothing
+      },
+      { enableHighAccuracy: true, timeout: 8000, maximumAge: 600000 }
+    );
+  }, []);
 
   return (
     <Box

--- a/React/weather-dashboard/src/components/SearchBar.jsx
+++ b/React/weather-dashboard/src/components/SearchBar.jsx
@@ -63,6 +63,33 @@ const SearchBar = ({ onCitySelect }) => {
     setSuggestions([]);
   };
 
+  const fetchWeatherForCoords = async (lat, lon) => {
+    try {
+      const response = await axios.get(
+        `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${
+          import.meta.env.VITE_OPEN_WEATHER_APP_KEY
+        }&units=metric`
+      );
+      onCitySelect(response.data);
+    } catch (error) {
+      console.error("Error fetching weather data by coordinates:", error);
+    }
+  };
+
+  const handleUseMyLocation = () => {
+    if (!("geolocation" in navigator)) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        fetchWeatherForCoords(latitude, longitude);
+      },
+      (err) => {
+        console.warn("Geolocation permission denied or unavailable", err);
+      },
+      { enableHighAccuracy: true, timeout: 8000, maximumAge: 600000 }
+    );
+  };
+
   return (
     <Box mt={5} p={3} sx={{ maxWidth: 600, mx: "auto" }}>
       <Box textAlign="center" mb={3}>
@@ -88,6 +115,9 @@ const SearchBar = ({ onCitySelect }) => {
           onClick={handleSearchClick}
         >
           Search
+        </Button>
+        <Button variant="outlined" color="secondary" onClick={handleUseMyLocation}>
+          Use My Location
         </Button>
       </Box>
       {query !== "" && suggestions.length === 0 && (


### PR DESCRIPTION
## Summary
Add real-time geolocation to the Weather Dashboard:
- Auto-detects user location on first load and loads local weather
- Adds a “Use My Location” button to fetch weather via current coordinates

## Changes
- App.jsx: auto geolocation on mount; fetch weather by lat/lon (OpenWeather)
- components/SearchBar.jsx: new “Use My Location” button; fetch by lat/lon
- Handles permission denials and failures gracefully (no crashes; manual search still works)

## Motivation / Context
Improves first-run UX and reduces friction for users who just want local weather without typing a city. Feature request from discussion on enhancing the dashboard.

## How to Test
1) Ensure `VITE_OPEN_WEATHER_APP_KEY` is set in the weather app environment
2) Run: `cd React/weather-dashboard && npm install && npm run dev`
3) On first load, allow location permission; verify weather populates for your area
4) Click “Use My Location” to re-fetch and confirm weather updates
5) Deny permission and confirm app remains usable (manual search works, no errors)

